### PR TITLE
Update basic_setup - add npm config set sign-git-tag true

### DIFF
--- a/basic_setup
+++ b/basic_setup
@@ -1,3 +1,4 @@
+npm config set sign-git-tag true
 git config --global gpg.format ssh
 git config --global commit.gpgSign true
 git config --global user.email "22254235+crislin2046@users.noreply.github.com"


### PR DESCRIPTION
This is necessary, so we achieve verified commit and tag status. Now we will sign the tags for releases and versions with our  regular key.